### PR TITLE
Log ZIP errors when local.mrpack cannot be opened

### DIFF
--- a/src/main/java/eu/pb4/mrpackserver/util/Utils.java
+++ b/src/main/java/eu/pb4/mrpackserver/util/Utils.java
@@ -108,7 +108,8 @@ public interface Utils {
                 }
 
             } catch (Throwable e) {
-                // ignored
+                Logger.error("Found local.mrpack, but could not open it as a ZIP archive!",
+                e);
             }
         }
         return null;


### PR DESCRIPTION
When local.mrpack exists but Java rejects its ZIP entry names, mrpack4server currently swallows the exception and shows
  "Couldn't find modpack definition!".
This change logs the underlying error so users can diagnose invalid mrpack files.